### PR TITLE
Fix an issue that SRT time format is incorrect

### DIFF
--- a/modules/module.vttconvert.js
+++ b/modules/module.vttconvert.js
@@ -161,7 +161,7 @@ function toSubsTime(str, srtFormat) {
     sx = sx.toFixed(msLen).split('.');
     
     
-    n.unshift(padTimeNum('.', sx[1], msLen));
+    n.unshift(padTimeNum((srtFormat ? ',' : '.'), sx[1], msLen));
     sx = Number(sx[0]);
     
     n.unshift(padTimeNum(':', sx%60, 2));


### PR DESCRIPTION
On the 4.7.0 update of funimation-downloader-nx, the `vttconvert` module is added.  
However, it has a bug that SRT time format is not processed correctly. Here is the example of it:

```
83
00:05:08.125 --> 00:05:12.000
WHOSE FAULT THIS IS! -
HERE! LET'S SEE.

84
00:05:12.083 --> 00:05:14.250
ACCORDING TO THE LEDGER
THAT I'VE BEEN KEEPING,

85
00:05:14.333 --> 00:05:16.833
AS OF TODAY,
THE SECURITY COMMITTEE'S
```

As you can see, the separator between milliseconds and seconds is a period, but official SRT format defines it as a comma.  
I have fixed this problem without changing except for a line of code.